### PR TITLE
Replace instanceof by constructor name check

### DIFF
--- a/src/convert/index.js
+++ b/src/convert/index.js
@@ -1,8 +1,7 @@
-const _ = require('lodash');
-const Y = require('yjs');
-const arrayEvent = require('./arrayEvent');
-const mapEvent = require('./mapEvent');
-const textEvent = require('./textEvent');
+const _ = require("lodash");
+const arrayEvent = require("./arrayEvent");
+const mapEvent = require("./mapEvent");
+const textEvent = require("./textEvent");
 
 /**
  * Converts yjs events into slate operations.
@@ -19,19 +18,19 @@ const toSlateOps = (events) => {
  * toSlateOp(event: Y.YEvent): Operation[]
  */
 const toSlateOp = (event) => {
-  if (event instanceof Y.YArrayEvent) {
+  if (event.constructor.name === "YArrayEvent") {
     return arrayEvent(event);
   }
 
-  if (event instanceof Y.YMapEvent) {
+  if (event.constructor.name === "YMapEvent") {
     return mapEvent(event);
   }
 
-  if (event instanceof Y.YTextEvent) {
+  if (event.constructor.name === "YTextEvent") {
     return textEvent(event);
   }
 
-  throw new Error('Unsupported yjs event');
+  throw new Error("Unsupported yjs event");
 };
 
 module.exports = { toSlateOps, toSlateOp };

--- a/src/convert/textEvent.js
+++ b/src/convert/textEvent.js
@@ -1,4 +1,3 @@
-const Y = require('yjs');
 const { toSlatePath } = require('../utils/convert');
 
 /**
@@ -37,7 +36,7 @@ const textEvent = (event) => {
       while (text.length < d.delete) {
         const item = removedValues.next().value;
         const { content } = item;
-        if (!(content instanceof Y.ContentString)) {
+        if (!(content && content.constructor.name === "ContentString")) {
           throw new TypeError(`Unsupported content type ${item.content}`);
         }
         text = text.concat(content.str);

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -25,7 +25,7 @@ const SyncNode = {
    * getChildren(node: SyncNode): Y.Array<SyncElement> | undefined
    */
   getChildren(node) {
-    if (node instanceof Y.Array) {
+    if (node && node.constructor.name === "YArray") {
       return node;
     }
 
@@ -36,7 +36,7 @@ const SyncNode = {
    * getText(node: SyncNode): Y.Text | undefined
    */
   getText(node) {
-    if (node instanceof Y.Array) {
+    if (node && node.constructor.name === "YArray") {
       return undefined;
     }
 


### PR DESCRIPTION
Couldn't get a test to reproduce the issue happening when integrating with `hg-web-ui`. When the module references Yjs from a peer dependency, `instanceof` always fails. Not sure why, so I figured this check should do the trick.