### PR TITLE
Make Yjs a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "slate-yjs",
+  "name": "hg-slate-yjs",
   "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
@@ -7709,9 +7709,10 @@
       }
     },
     "yjs": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.4.3.tgz",
-      "integrity": "sha512-jHlk3SKz2gC/rO0WBEuyn8yxtxEjDDMuANQYLR7EJjdbYhbdKYiaoPsNsFOgMDy7u8R6i2N3gVIRcmXYrbAvzg==",
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.4.6.tgz",
+      "integrity": "sha512-BBHviAh3RTgp5Us4SubcAyxXFaLQ/552DzR0z3YZT1/HZLCpJc57cf6X0ZuuCGs8RFkgISYrbIFMrZ1L1NTzPA==",
+      "dev": true,
       "requires": {
         "lib0": "^0.2.33"
       }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "slate-hyperscript": "^0.10.8",
     "ts-jest": "26.4.3",
     "ts-node": "9.0.0",
-    "typescript": "4.0.5"
+    "typescript": "4.0.5",
+    "yjs": "^13.4.3"
   },
   "dependencies": {
     "immutable": "^3.8.2",
@@ -59,7 +60,9 @@
     "react": "^16.9.0",
     "slate": "https://registry.npmjs.org/@hugo-team/slate/-/slate-0.41.6.tgz",
     "y-protocols": "^1.0.1",
-    "y-websocket": "^1.3.2",
+    "y-websocket": "^1.3.2"
+  },
+  "peerDependencies": {
     "yjs": "^13.4.3"
   },
   "babel": {


### PR DESCRIPTION
Found the culprit of the `instanceof` checks failing.
Module resolution ends up with two instances of the Yjs module, because the project importing this module would also import Yjs directly. So when checking for the type of a instance, it would fail because the class on the right hand side of the comparison was different from the one that created the instance.

Moving Yjs to the `peerDependencies` section basically tells NPM to trust that a Yjs module will be in the system that this module will be imported, so it won't create a copy.