### PR TITLE
Add support for converting between Slate and Yjs representations of marks/formatting

### DIFF
--- a/src/apply/index.js
+++ b/src/apply/index.js
@@ -2,6 +2,7 @@ const { Operation } = require('slate');
 const node = require('./node');
 const text = require('./text');
 const value = require('./value')
+const mark = require('./mark')
 
 const nullOp = (doc) => doc;
 
@@ -9,6 +10,7 @@ const opMappers = {
   ...text,
   ...node,
   ...value,
+  ...mark,
 
   // SetSelection is currently a null op since we don't support cursors
   set_selection: nullOp,

--- a/src/convert/textEvent.js
+++ b/src/convert/textEvent.js
@@ -9,7 +9,11 @@ const textEvent = (event) => {
   const eventTargetPath = toSlatePath(event.path);
 
   /**
-   * createTextOp(type: 'insert_text'|'remove_text', offset: number, text: string): TextOperation
+   * createTextOp(
+   *   type: 'insert_text'|'remove_text', 
+   *   offset: number, 
+   *   text: string, 
+   *   marks: Mark[]): TextOperation
    */
   const createTextOp = (type, offset, text, marks = []) => {
     return {
@@ -22,7 +26,10 @@ const textEvent = (event) => {
   };
 
   /**
-   * createAddMarkOp(offset: number, length: number, attributes: Object<string, string>): MarkOperation
+   * createAddMarkOp(
+   *   offset: number, 
+   *   length: number, 
+   *   attributes: Object<string, string>): MarkOperation
    */
   const createAddMarkOp = (offset, length, attributes) => {
     // It appears that (a) an 'add_mark' op can only contain a single mark and

--- a/src/convert/textEvent.js
+++ b/src/convert/textEvent.js
@@ -25,12 +25,22 @@ const textEvent = (event) => {
    * createAddMarkOp(offset: number, length: number, attributes: Object<string, string>): MarkOperation
    */
   const createAddMarkOp = (offset, length, attributes) => {
+    // It appears that (a) an 'add_mark' op can only contain a single mark and
+    // (b) that 'retain' elements in Yjs TextEvents are aligned with this; log
+    // an error if that is not the case. (If we do see 'retain' elements that
+    // yield multiple marks, we probably need to change things such that this
+    // code can return multiple ops, one per mark.)
+    const marks = toSlateMarks(attributes);
+    if (marks.length > 1) {
+      console.error(`Attributes yield more than one mark: ${attributes}`);
+    }
+
     return {
       type: 'add_mark',
       path: eventTargetPath,
       offset,
       length,
-      mark: toSlateMarks(attributes)[0],
+      mark: marks[0],
     };
   };
 

--- a/src/convert/textEvent.js
+++ b/src/convert/textEvent.js
@@ -1,4 +1,4 @@
-const { toSlatePath } = require('../utils/convert');
+const { toSlateMarks, toSlatePath } = require('../utils/convert');
 
 /**
  * Converts a Yjs Text event into Slate operations.
@@ -11,13 +11,26 @@ const textEvent = (event) => {
   /**
    * createTextOp(type: 'insert_text'|'remove_text', offset: number, text: string): TextOperation
    */
-  const createTextOp = (type, offset, text) => {
+  const createTextOp = (type, offset, text, marks = []) => {
     return {
       type,
       offset,
       text,
       path: eventTargetPath,
-      marks: [],
+      marks,
+    };
+  };
+
+  /**
+   * createAddMarkOp(offset: number, length: number, attributes: Object<string, string>): MarkOperation
+   */
+  const createAddMarkOp = (offset, length, attributes) => {
+    return {
+      type: 'add_mark',
+      path: eventTargetPath,
+      offset,
+      length,
+      mark: toSlateMarks(attributes)[0],
     };
   };
 
@@ -26,9 +39,13 @@ const textEvent = (event) => {
   let addOffset = 0;
   const removeOps = [];
   const addOps = [];
-  for (const delta of event.changes.delta) {
+  const markOps = [];
+  for (const delta of event.delta) {
     const d = delta;
     if (d.retain !== undefined) {
+      if (!!d.attributes) {
+        markOps.push(createAddMarkOp(addOffset, d.retain, d.attributes));
+      }
       removeOffset += d.retain;
       addOffset += d.retain;
     } else if (d.delete !== undefined) {
@@ -48,12 +65,12 @@ const textEvent = (event) => {
       }
       removeOps.push(createTextOp('remove_text', removeOffset, text));
     } else if (d.insert !== undefined) {
-      addOps.push(createTextOp('insert_text', addOffset, d.insert.join('')));
+      addOps.push(createTextOp('insert_text', addOffset, d.insert, toSlateMarks(d.attributes)));
       addOffset += d.insert.length;
     }
   }
 
-  return [...removeOps, ...addOps];
+  return [...removeOps, ...addOps, ...markOps];
 };
 
 module.exports = textEvent;

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1,4 +1,4 @@
-const { Block, Inline, Text } = require('slate');
+const { Block, Inline, Leaf, Mark, Text } = require('slate');
 const isPlainObject = require('is-plain-object');
 const Y = require('yjs');
 const { SyncElement } = require('../model');
@@ -43,8 +43,7 @@ const toSlateNode = (element) => {
   } else if (object === 'text') {
     const text = SyncElement.getText(element);
     attrs = {
-      text: text.toString(),
-      marks: Set(element.get('marks')),
+      leaves: text.toDelta().map(toSlateLeaf),
       ...attrs,
     };
     return Text.create(attrs);
@@ -52,6 +51,38 @@ const toSlateNode = (element) => {
 
   throw new Error(`Unable to convert '${object}' element`);
 };
+
+/**
+ * Converts a Quill delta element (as returned from Y.Text.toDelta()) to a slate
+ * Leaf
+ *
+ * toSlateLeaf(delta): Leaf
+ */
+const toSlateLeaf = (delta) => {
+  if (!delta.insert) {
+    throw new Error(`Unable to convert '${delta}' element`);
+  }
+
+  return Leaf.create({
+    text: delta.insert,
+    marks: toSlateMarks(delta.attributes),
+  });
+}
+
+/**
+ * Converts Yjs formatting attributes to a List of slate Marks
+ *
+ * toSlateMarks(Object<string, string>): Mark[]
+ */
+const toSlateMarks = (attributes) => {
+  const marks = [];
+  if (!!attributes) {
+    for (const markType in attributes) {
+      marks.push(Mark.create({ type: markType }));
+    }
+  }
+  return marks;
+}
 
 /**
  * Converts a SyncDoc to a Slate doc
@@ -90,7 +121,13 @@ const toSyncElement = (node) => {
   if (Text.isText(node)) {
     const textElement = new Y.Text(node.text);
     element.set('text', textElement);
-    element.set('marks', node.getMarks().toJSON());
+    let index = 0;
+    node.getLeaves().forEach(leaf => {
+      if (leaf.marks.size > 0) {
+        textElement.format(index, leaf.text.length, toFormattingAttributes(leaf.marks));
+      }
+      index += leaf.text.length;
+    });
   }
 
   for (const [key, value] of Object.entries(node.toJSON())) {
@@ -100,6 +137,19 @@ const toSyncElement = (node) => {
   }
 
   return element;
+};
+
+/**
+ * Converts a List of slate Marks to Yjs formatting attributes
+ *
+ * toFormattingAttributes(List<Mark>): Object<string, string>
+ */
+const toFormattingAttributes = (marks) => {
+  const result = {};
+  marks.forEach(mark => {
+    result[mark.type] = 'true';
+  })
+  return result;
 };
 
 /**

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -162,6 +162,8 @@ const toSlatePath = (path) => {
 };
 
 module.exports = {
+  toFormattingAttributes,
+  toSlateMarks,
   toSlateNode,
   toSlateDoc,
   toSyncDoc,

--- a/test/apply/apply.test.js
+++ b/test/apply/apply.test.js
@@ -1,7 +1,7 @@
 const { applySlateOp, applySlateOps, toSlateDoc} = require('../../src');
 const { createLine, createDoc, createText, createSlateValue } = require('../utils');
 const { List } = require('immutable');
-const { Operation } = require('slate');
+const { Operation, Text } = require('slate');
 const Y = require("yjs")
 
 const transforms = [
@@ -210,6 +210,38 @@ const transforms = [
       createLine([createText('Hello ')]),
       createLine([createText('collaborator!')])
     ]
+  ],
+  [
+    'add_mark',
+    [
+      createLine([createText('hotel uniform golf oscar')])
+    ],
+    [
+      {
+        path: [0, 0],
+        offset: 6,
+        length: 12,
+        mark: { type: 'strong' },
+        type: 'add_mark'
+      },
+      {
+        path: [0, 0],
+        offset: 0,
+        length: 13,
+        mark: { type: 'em' },
+        type: 'add_mark'
+      }
+    ],
+    [
+      createLine([Text.create({
+        leaves: [
+          { text: 'hotel ', marks: [{ type: 'em' }]},
+          { text: 'uniform', marks: [{ type: 'em' }, { type: 'strong' }]},
+          { text: ' golf', marks: [{ type: 'strong' }]},
+          { text: ' oscar' },
+        ],
+      })])
+    ],
   ]
 ];
 

--- a/test/collaboration.test.js
+++ b/test/collaboration.test.js
@@ -1,6 +1,7 @@
 const { TestEditor } = require('./testEditor');
 const { toSlateDoc } = require('../src');
 const { createLine, createText } = require('./utils');
+const { Text } = require('slate');
 const Y = require('yjs');
 
 const tests = [
@@ -325,6 +326,34 @@ const tests = [
     ],
     [createLine([createText('')])],
   ],
+  [
+    'Add marks to existing text',
+    [
+      createLine([createText('alfa bravo charlie')]),
+    ],
+    [
+      TestEditor.makeAddMark([0, 0], 0, 4, 'underline'),
+    ],
+    [
+      createLine([
+        Text.create({ leaves: [
+          { text: 'alfa', marks: [{ type: 'underline' }]},
+          { text: ' bravo charlie' }
+        ]})]),
+    ],
+    [
+      TestEditor.makeAddMark([0, 0], 5, 5, 'strong'),
+    ],
+    [
+      createLine([
+        Text.create({ leaves: [
+          { text: 'alfa', marks: [{ type: 'underline' }]},
+          { text: ' ' },
+          { text: 'bravo', marks: [{ type: 'strong' }]},
+          { text: ' charlie' }
+        ]})]),
+    ],
+  ],
 ];
 
 const nodeToJSON = (node) => node.toJSON();
@@ -362,15 +391,16 @@ describe('slate operations propagate between editors', () => {
         updates = TestEditor.getCapturedYjsUpdates(src);
         TestEditor.applyYjsUpdatesToYjs(dst, updates);
 
-        // Verify final states.
+        // Verify final 'document' states.
         const outputAsJSON = output.map(nodeToJSON);
         expect(src.slateDoc.document.nodes.toArray().map(nodeToJSON)).toStrictEqual(outputAsJSON);
         expect(toSlateDoc(src.syncDoc.get('document')).map(nodeToJSON)).toStrictEqual(outputAsJSON);
         expect(toSlateDoc(dst.syncDoc.get('document')).map(nodeToJSON)).toStrictEqual(outputAsJSON);
-        expect(dst.syncDoc.get('data').toJSON()).toStrictEqual(src.syncDoc.get('data').toJSON());
         expect(dst.slateDoc.document.nodes.toArray().map(nodeToJSON)).toStrictEqual(outputAsJSON);
-        expect(src.slateDoc.data.toJSON()).toStrictEqual(dst.slateDoc.data.toJSON());
 
+        // Verify final 'data' states.
+        expect(dst.syncDoc.get('data').toJSON()).toStrictEqual(src.syncDoc.get('data').toJSON());
+        expect(src.slateDoc.data.toJSON()).toStrictEqual(dst.slateDoc.data.toJSON());
       }
     });
   });

--- a/test/concurrent.test.js
+++ b/test/concurrent.test.js
@@ -123,14 +123,6 @@ const tests = [
     transform: TestEditor.makeRemoveNodes([1, 0]),
   },
   {
-    name: 'Update the TopLevel Data 1',
-    transform: TestEditor.makeSetValue({createdBy:{
-      emailAddress: "danielblank07@gmail.com",
-      id: "ac8e5fe7-af4e-4281-b1e2-53630606e7c6",
-    }})
-  },
-  
-  {
     name: 'Remove text node from 3nd paragraph',
     transform: TestEditor.makeRemoveNodes([2, 0]),
   },
@@ -155,20 +147,51 @@ const tests = [
     transform: TestEditor.makeSplitNodes({ path: [3, 0], offset: 7}),
   },
   {
-    name: 'Update the TopLevel Data 2',
-    transform: TestEditor.makeSetValue({createdBy:{
-      emailAddress: "danielblank07@gmail.com",
-      id: "ac8e5fe7-af4e-4281-b1e2-53630606e7c6",
-      name: "Daniel Blank",
-    }})
-  },
-  {
     name: 'Move 1st paragraph',
     transform: TestEditor.makeMoveNodes([0], [3]),
   },
   {
     name: 'Move 2nd paragraph',
     transform: TestEditor.makeMoveNodes([3], [2]),
+  },
+  {
+    name: 'Move 3rd paragraph',
+    transform: TestEditor.makeMoveNodes([2], [1]),
+  },
+  {
+    name: 'Move 4th paragraph',
+    transform: TestEditor.makeMoveNodes([1], [0]),
+  },
+  {
+    name: 'Add formatting to 1st paragraph',
+    transform: TestEditor.makeAddMark([0, 0], 1, 9, 'strong'),
+  },
+  {
+    name: 'Add formatting to 2nd paragraph',
+    transform: TestEditor.makeAddMark([1, 0], 2, 11, 'em'),
+  },
+  {
+    name: 'Add formatting to 3rd paragraph',
+    transform: TestEditor.makeAddMark([2, 0], 3, 6, 'underline'),
+  },
+  {
+    name: 'Add formatting to 4th paragraph',
+    transform: TestEditor.makeAddMark([3, 0], 4, 2, 'strong'),
+  },
+  {
+    name: 'Update the TopLevel Data 1',
+    transform: TestEditor.makeSetValue({createdBy:{
+      emailAddress: "danielblank07@gmail.com",
+      id: "ac8e5fe7-af4e-4281-b1e2-53630606e7c6",
+    }})
+  },
+  {
+    name: 'Update the TopLevel Data 2',
+    transform: TestEditor.makeSetValue({createdBy:{
+      emailAddress: "danielblank07@gmail.com",
+      id: "ac8e5fe7-af4e-4281-b1e2-53630606e7c6",
+      name: "Daniel Blank",
+    }})
   },
   {
     name: 'Update the TopLevel Data 3',
@@ -179,14 +202,6 @@ const tests = [
       pictureUrl: "https://lh4.googleusercontent.com/-Au4KLfih-zQ/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rcJjTL-m5CILVsClpS2Om3OQycCcQ/photo.jpg",
       teamId: "8d930c14-9116-4984-b5c8-cdee9432ae87"
     }})
-  },
-  {
-    name: 'Move 3rd paragraph',
-    transform: TestEditor.makeMoveNodes([2], [1]),
-  },
-  {
-    name: 'Move 4th paragraph',
-    transform: TestEditor.makeMoveNodes([1], [0]),
   },
 ];
 
@@ -205,12 +220,16 @@ const runOneTest = async (ti, tj) => {
   const updates = TestEditor.getCapturedYjsUpdates(ei);
   TestEditor.applyYjsUpdatesToYjs(ej, updates);
 
-  // Verify initial states match.
+  // Verify initial 'document' states.
   expect(ei.slateDoc.document.nodes.toArray().map(nodeToJSON))
     .toEqual(ej.slateDoc.document.nodes.toArray().map(nodeToJSON));
   expect(toSlateDoc(ei.syncDoc.get('document')).map(nodeToJSON))
     .toEqual(toSlateDoc(ej.syncDoc.get('document')).map(nodeToJSON));
-    expect(ei.syncDoc.get('data').toJSON())
+
+  // Verify initial 'data' states.
+  expect(ei.slateDoc.data.toJSON())
+    .toEqual(ej.slateDoc.data.toJSON());
+  expect(ei.syncDoc.get('data').toJSON())
     .toEqual(ej.syncDoc.get('data').toJSON());
 
   // Apply 1st transform to 1st editor, capture updates.
@@ -225,15 +244,17 @@ const runOneTest = async (ti, tj) => {
   TestEditor.applyYjsUpdatesToYjs(ei, updatesFromJ);
   TestEditor.applyYjsUpdatesToYjs(ej, updatesFromI);
 
-  // Verify final states match.
-  expect(ei.slateDoc.document.nodes.toArray().map(nodeToJSON))
-    .toEqual(ej.slateDoc.document.nodes.toArray().map(nodeToJSON));
+  // Verify final 'document' states.
   expect(toSlateDoc(ei.syncDoc.get('document')).map(nodeToJSON))
     .toEqual(toSlateDoc(ej.syncDoc.get('document')).map(nodeToJSON));
-  expect(ei.slateDoc.data.toJSON())
-    .toEqual(ej.slateDoc.data.toJSON());
+  expect(ei.slateDoc.document.nodes.toArray().map(nodeToJSON))
+    .toEqual(ej.slateDoc.document.nodes.toArray().map(nodeToJSON));
+
+  // Verify final 'data' states.
   expect(ei.syncDoc.get('data').toJSON())
     .toEqual(ej.syncDoc.get('data').toJSON());
+  expect(ei.slateDoc.data.toJSON())
+    .toEqual(ej.slateDoc.data.toJSON());
 }
 
 describe('model concurrent edits in separate editors', () => {

--- a/test/convert/convert.test.js
+++ b/test/convert/convert.test.js
@@ -1,3 +1,4 @@
+const { Text } = require('slate');
 const { toSlateDoc, toSyncDoc } = require('../../src');
 const { createLine, createMention, createText } = require('../utils');
 const Y = require('yjs');
@@ -21,6 +22,23 @@ const tests = [
   [
     'block node with properties',
     createLine([createText('mno')], { pqr: 'stu' })
+  ],
+  [
+    'text with marks',
+    Text.create({
+      leaves: [
+        { text: 'ab' },
+        {
+          text: 'cde',
+          marks: [{ type: 'strong' }]
+        },
+        {
+          text: 'fghi',
+          marks: [{ type: 'em' }, { type: 'underline' }]
+        },
+        { text: 'jklmn' },
+      ],
+    })
   ],
 ];
 

--- a/test/testEditor.js
+++ b/test/testEditor.js
@@ -224,12 +224,24 @@ const TestEditor = {
       e.slateDoc = change.value;
     };
   },
+
   /**
    * makeSetValue(Properties: Properties): TransformFunc
    */
   makeSetValue(properties) {
     return (e) => {
       const change = e.slateDoc.change().setValue({data: properties})
+      TestEditor.applySlateOpsToYjs(e, change.operations);
+      e.slateDoc = change.value;
+    };
+  },
+
+  /**
+   * makeAddMark(path: Path, offset: number, length: number, markType: string): TransformFunc
+   */
+  makeAddMark(path, offset, length, markType) {
+    return (e) => {
+      const change = e.slateDoc.change().addMarkByPath(path, offset, length, { type: markType });
       TestEditor.applySlateOpsToYjs(e, change.operations);
       e.slateDoc = change.value;
     };


### PR DESCRIPTION
* Yjs represents a Slate Text node as a single Y.Text object, carrying over any Slate Marks as formatting attributes
