### PR TITLE
Fix add_mark bugs

### DIFF
--- a/src/convert/textEvent.js
+++ b/src/convert/textEvent.js
@@ -26,28 +26,29 @@ const textEvent = (event) => {
   };
 
   /**
-   * createAddMarkOp(
+   * createMarkOp(
    *   offset: number, 
    *   length: number, 
    *   attributes: Object<string, string>): MarkOperation
    */
-  const createAddMarkOp = (offset, length, attributes) => {
-    // It appears that (a) an 'add_mark' op can only contain a single mark and
-    // (b) that 'retain' elements in Yjs TextEvents are aligned with this; log
-    // an error if that is not the case. (If we do see 'retain' elements that
-    // yield multiple marks, we probably need to change things such that this
-    // code can return multiple ops, one per mark.)
+  const createMarkOp = (offset, length, attributes) => {
+    // It appears that (a) an 'add_mark' or 'remove_mark' op can only contain a
+    // single mark and (b) that 'retain' elements in Yjs TextEvents are aligned
+    // with this; log an error if that is not the case. (If we do see 'retain'
+    // elements that yield multiple marks, we probably need to change things
+    // such that this code can return multiple ops, one per mark.)
     const marks = toSlateMarks(attributes);
     if (marks.length > 1) {
       console.error(`Attributes yield more than one mark: ${attributes}`);
     }
+    const mark = marks[0];
 
     return {
-      type: 'add_mark',
+      type: ((attributes[mark.type] !== null) ? 'add_mark' : 'remove_mark'),
       path: eventTargetPath,
       offset,
       length,
-      mark: marks[0],
+      mark,
     };
   };
 
@@ -61,7 +62,7 @@ const textEvent = (event) => {
     const d = delta;
     if (d.retain !== undefined) {
       if (!!d.attributes) {
-        markOps.push(createAddMarkOp(addOffset, d.retain, d.attributes));
+        markOps.push(createMarkOp(addOffset, d.retain, d.attributes));
       }
       removeOffset += d.retain;
       addOffset += d.retain;

--- a/test/concurrent.test.js
+++ b/test/concurrent.test.js
@@ -93,12 +93,6 @@ const tests = [
     transform: TestEditor.makeMergeNodes([3]),
   },
   {
-    name: 'Add TopLevel data',
-    transform: TestEditor.makeSetValue({createdBy:{
-      emailAddress: "danielblank07@gmail.com",
-    }})
-  },
-  {
     name: 'Remove 1st paragraph',
     transform: TestEditor.makeRemoveNodes([0]),
   },
@@ -170,15 +164,21 @@ const tests = [
     name: 'Add formatting to 2nd paragraph',
     transform: TestEditor.makeAddMark([1, 0], 2, 11, 'em'),
   },
-  // Temporarily comment out the following, as they are causing test failures. 
-  //  {
-  //    name: 'Add formatting to 3rd paragraph',
-  //    transform: TestEditor.makeAddMark([2, 0], 3, 6, 'underline'),
-  //  },
+  {
+    name: 'Add formatting to 3rd paragraph',
+    transform: TestEditor.makeAddMark([2, 0], 3, 6, 'underline'),
+  },
+  // Temporarily comment out the following, as it is causing test failures.
   //  {
   //    name: 'Add formatting to 4th paragraph',
   //    transform: TestEditor.makeAddMark([3, 0], 4, 2, 'strong'),
   //  },
+  {
+    name: 'Add TopLevel data',
+    transform: TestEditor.makeSetValue({createdBy:{
+      emailAddress: "danielblank07@gmail.com",
+    }})
+  },
   {
     name: 'Update the TopLevel Data 1',
     transform: TestEditor.makeSetValue({createdBy:{


### PR DESCRIPTION
* In a 'retain' delta element in a Yjs TextEvent, if the value of a formatting attribute is null, generate a 'remove_mark' op instead of an 'add_mark' op

* This still leaves one failing test (commented out for now); at this point, I have some suspicion that Yjs may be generating a buggy TextEvent -- I'll work on trying to replicate things in a simpler/standalone test.