### PR TITLE
Preliminary support for 'remove_mark' ops

### DIFF
--- a/src/apply/mark/removeMark.js
+++ b/src/apply/mark/removeMark.js
@@ -1,5 +1,17 @@
+const { SyncElement } = require('../../model');
+const { getTarget } = require('../../path');
+const { toFormattingAttributes } = require('../../utils');
+
+/**
+ * Applies a remove mark operation to a SyncDoc.
+ *
+ * removeMark(doc: SyncDoc, op: MarkOperation): SyncDoc
+ */
 const removeMark = (doc, op) => {
-  throw new Error('removeMark - NOT IMPLEMENTED');
+  const syncDoc = doc.get('document')
+  const node = getTarget(syncDoc, op.path);
+  const nodeText = SyncElement.getText(node);
+  nodeText.format(op.offset, op.length, toFormattingAttributes([op.mark], false));
   return doc;
 };
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -142,12 +142,19 @@ const toSyncElement = (node) => {
 /**
  * Converts a List of slate Marks to Yjs formatting attributes
  *
- * toFormattingAttributes(List<Mark>): Object<string, string>
+ * toFormattingAttributes(List<Mark>, boolean): Object<string, string>
  */
-const toFormattingAttributes = (marks) => {
+const toFormattingAttributes = (marks, setMark = true) => {
   const result = {};
   marks.forEach(mark => {
-    result[mark.type] = 'true';
+    // If setMark is false, use a value of null to indicate that application of
+    // the resulting formatting attributes should cause the mark to be cleared.
+    //
+    // TBD: Perhaps use true (boolean) instead of 'true' (string) here?
+    // Currently using 'true' because the Yjs API documentation suggests that
+    // the formatting attributes should be Object<string, string>, though the
+    // provided example seems to show Object<string, boolean> instead ...
+    result[mark.type] = setMark ? 'true' : null;
   })
   return result;
 };

--- a/test/apply/apply.test.js
+++ b/test/apply/apply.test.js
@@ -242,6 +242,38 @@ const transforms = [
         ],
       })])
     ],
+  ],
+  [
+    'remove_mark',
+    [
+      createLine([Text.create({
+        leaves: [
+          { text: 'hotel ', marks: [{ type: 'em' }]},
+          { text: 'uniform', marks: [{ type: 'em' }, { type: 'strong' }]},
+          { text: ' golf', marks: [{ type: 'strong' }]},
+          { text: ' oscar' },
+        ],
+      })])
+    ],
+    [
+      {
+        path: [0, 0],
+        offset: 0,
+        length: 13,
+        mark: { type: 'em' },
+        type: 'remove_mark'
+      },
+      {
+        path: [0, 0],
+        offset: 6,
+        length: 12,
+        mark: { type: 'strong' },
+        type: 'remove_mark'
+      },
+    ],
+    [
+      createLine([createText('hotel uniform golf oscar')])
+    ],
   ]
 ];
 

--- a/test/collaboration.test.js
+++ b/test/collaboration.test.js
@@ -354,6 +354,42 @@ const tests = [
         ]})]),
     ],
   ],
+  [
+    'Remove marks from existing text',
+    [
+      createLine([
+        Text.create({ leaves: [
+          { text: 'alfa ', marks: [{ type: 'strong' }]},
+          { text: 'bravo charlie', marks: [{ type: 'em' }]},
+          { text: ' delta' }
+        ]})]),
+    ],
+    [
+      TestEditor.makeRemoveMark([0, 0], 1, 4, 'strong'),
+    ],
+    [
+      createLine([
+        Text.create({ leaves: [
+          { text: 'a', marks: [{ type: 'strong' }]},
+          { text: 'lfa ' },
+          { text: 'bravo charlie', marks: [{ type: 'em' }]},
+          { text: ' delta' }
+        ]})]),
+    ],
+    [
+      TestEditor.makeRemoveMark([0, 0], 7, 11, 'em'),
+    ],
+    [
+      createLine([
+        Text.create({ leaves: [
+          { text: 'a', marks: [{ type: 'strong' }]},
+          { text: 'lfa ' },
+          { text: 'br', marks: [{ type: 'em' }]},
+          { text: 'avo charlie' },
+          { text: ' delta' }
+        ]})]),
+    ],
+  ],
 ];
 
 const nodeToJSON = (node) => node.toJSON();

--- a/test/testEditor.js
+++ b/test/testEditor.js
@@ -246,6 +246,17 @@ const TestEditor = {
       e.slateDoc = change.value;
     };
   },
+
+  /**
+   * makeRemoveMark(path: Path, offset: number, length: number, markType: string): TransformFunc
+   */
+  makeRemoveMark(path, offset, length, markType) {
+    return (e) => {
+      const change = e.slateDoc.change().removeMarkByPath(path, offset, length, { type: markType });
+      TestEditor.applySlateOpsToYjs(e, change.operations);
+      e.slateDoc = change.value;
+    };
+  },
 };
 
 module.exports = { TestEditor };


### PR DESCRIPTION
* Still digging in on extending concurrent.test -- adding pre-existing marks/formatting to the initial document state (so they could be be removed) seemed to cause some strange test failures, even before adding any 'remove_mark' test cases.
