### PR TITLE
Polish support for marks/formatting attributes

### DIFF
--- a/src/apply/node/mergeNode.js
+++ b/src/apply/node/mergeNode.js
@@ -19,7 +19,22 @@ const mergeNode = (doc, op) => {
   const nextText = SyncNode.getText(next);
 
   if (prevText && nextText) {
-    prevText.insert(prevText.length, nextText.toString());
+    // A bit of complexity: If prevText has formatting attributes that extend to
+    // the end of the text, then if we insert the contents of nextText at the
+    // end of prevText, those formatting attributes are extended to include the
+    // new contents, which is not what we want.
+    //
+    // Instead, we effect the merge by building a combined delta, deleting the
+    // existing contents of prevText, and then applying that delta. (It seems
+    // like one should be able to add a leading 'delete' element to the combined
+    // delta in order to delete the existing text, but that didn't have the
+    // desired effect, ergo doing it separately.)
+    const combinedDelta = [
+      ...prevText.toDelta(),
+      ...nextText.toDelta(),
+    ];
+    prevText.delete(0, prevText.length);
+    prevText.applyDelta(combinedDelta);
   } else {
     const toPush = SyncNode.getChildren(next).map(cloneSyncElement);
     SyncNode.getChildren(prev).push(toPush);

--- a/src/utils/clone.js
+++ b/src/utils/clone.js
@@ -13,6 +13,19 @@ const cloneSyncElement = (element) => {
   if (text !== undefined) {
     const textElement = new Y.Text(text.toString());
     clone.set('text', textElement);
+    let index = 0;
+    text.toDelta().forEach(d => {
+      if (!d.insert) {
+        // We expect the delta representation to only contain 'insert' elements.
+        throw new Error(`Unexpected delta element: ${d}`);
+      }
+      if (!!d.attributes) {
+        // If the current element contains formatting attributes, apply them to
+        // the cloned text.
+        textElement.format(index, d.insert.length, d.attributes);
+      }
+      index += d.insert.length;
+    });
   }
 
   if (children !== undefined) {

--- a/test/collaboration.test.js
+++ b/test/collaboration.test.js
@@ -83,24 +83,54 @@ const tests = [
   [
     'Merge two paragraph nodes',
     [
-      createLine([createText('Hello ')]),
-      createLine([createText('collaborator!')]),
+      createLine([
+        Text.create({ leaves: [
+          { text: 'Hello', marks: [{ type: 'strong' }]},
+          { text: ' ' },
+        ]})
+      ]),
+      createLine([
+        Text.create({ leaves: [
+          { text: 'collaborator!', marks: [{ type: 'em' }]},
+        ]})
+      ]),
     ],
     [TestEditor.makeMergeNodes([1])],
-    [createLine([createText('Hello collaborator!')])],
+    [
+      createLine([
+        Text.create({ leaves: [
+          { text: 'Hello', marks: [{ type: 'strong' }]},
+          { text: ' ' },
+          { text: 'collaborator!', marks: [{ type: 'em' }]}
+        ]})
+      ]),
+    ],
   ],
   [
+    // Also verifies that marks are preserved when moving nodes.
     'Move a paragraph node to an existing position',
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')]),
+      createLine([
+        Text.create({ leaves: [{ text: 'first', marks: [{ type: 'em' }]}]})
+      ]),
+      createLine([
+        Text.create({ leaves: [{ text: 'second', marks: [{ type: 'strong' }]}]})
+      ]),
+      createLine([
+        Text.create({ leaves: [{ text: 'third', marks: [{ type: 'underline' }]}]})
+      ]),
     ],
     [TestEditor.makeMoveNodes([1], [0])],
     [
-      createLine([createText('second')]),
-      createLine([createText('first')]),
-      createLine([createText('third')]),
+      createLine([
+        Text.create({ leaves: [{ text: 'second', marks: [{ type: 'strong' }]}]})
+      ]),
+      createLine([
+        Text.create({ leaves: [{ text: 'first', marks: [{ type: 'em' }]}]})
+      ]),
+      createLine([
+        Text.create({ leaves: [{ text: 'third', marks: [{ type: 'underline' }]}]})
+      ]),
     ],
   ],
   [

--- a/test/concurrent.test.js
+++ b/test/concurrent.test.js
@@ -1,13 +1,21 @@
 const { TestEditor } = require('./testEditor');
 const { toSlateDoc } = require('../src');
 const { createLine, createText } = require('./utils');
-
+const { Text } = require('slate');
 const Y = require('yjs');
 
 const initialState = [
-  createLine([createText('alfa bravo')]),
+  createLine([
+    Text.create({ leaves: [
+      { text: 'alfa brav' },
+      { text: 'o', marks: [{ type: 'em' }]}]})
+  ]),
   createLine([createText('charlie delta')]),
-  createLine([createText('echo foxtrot')]),
+  createLine([
+    Text.create({ leaves: [
+      { text: 'ech', marks: [{ type: 'strong' }]},
+      { text: 'o foxtrot' }]})
+  ]),
   createLine([createText('golf hotel')]),
 ];
 
@@ -171,6 +179,14 @@ const tests = [
   {
     name: 'Add formatting to 4th paragraph',
     transform: TestEditor.makeAddMark([3, 0], 4, 2, 'strong'),
+  },
+  {
+    name: 'Remove formatting from 1st paragraph',
+    transform: TestEditor.makeRemoveMark([0, 0], 9, 1, 'em'),
+  },
+  {
+    name: 'Remove formatting from 3rd paragraph',
+    transform: TestEditor.makeRemoveMark([2, 0], 0, 3, 'strong'),
   },
   {
     name: 'Add TopLevel data',


### PR DESCRIPTION
* Fix merge-nodes logic in the Slate->Yjs path to propagate marks/formatting attributes correctly.

* Fix textEvent-handling logic in Yjs->Slate path to handle formatting attributes that correspond to multiple marks (as seen in the wild when testing, resolving a comment there).

* Fix textEvent-handling logic in Yjs->Slate path to handle removed values that correspond to formatting attributes.

* Fix code for cloning Yjs Text elements to propagate formatting attributes to the cloned element.

* Update {collaboration,concurrent}.test.js to better exercise code that handles marks/formatting attributes.