### PR TITLE
Update toSyncDoc and toSlateDoc to use the new wrapper schema

### DIFF
--- a/src/path/index.js
+++ b/src/path/index.js
@@ -1,7 +1,6 @@
-const { Path } = require('slate');
-const Y = require('yjs');
-const { SyncDoc, SyncElement, SyncNode } = require('../model');
-const { toSlateDoc } = require('../utils/convert');
+const { Path } = require("slate");
+const Y = require("yjs");
+const { SyncDoc, SyncElement, SyncNode } = require("../model");
 
 /**
  * Returns the SyncNode referenced by the path
@@ -20,9 +19,7 @@ const getTarget = (doc, path) => {
     }
     if (!result) {
       throw new TypeError(
-        `path ${path.toString()} does not match doc ${JSON.stringify(
-          toSlateDoc(doc)
-        )}`
+        `path ${path.toString()} does not match doc ${JSON.stringify(doc)}`
       );
     }
     return result;
@@ -36,7 +33,7 @@ const getTarget = (doc, path) => {
  */
 const getParentPath = (path, level = 1) => {
   if (level > path.size) {
-    throw new TypeError('requested ancestor is higher than root');
+    throw new TypeError("requested ancestor is higher than root");
   }
 
   return [path.get(path.size - level), path.slice(0, path.size - level)];

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1,16 +1,8 @@
-const { Block, Inline, Leaf, Mark, Text } = require('slate');
+const { Block, Document, Inline, Leaf, Mark, Text, Value } = require('slate');
 const isPlainObject = require('is-plain-object');
 const Y = require('yjs');
 const { SyncElement } = require('../model');
 const { Set } = require('immutable');
-
-/**
- * isElement(value): boolean
- */
-const isElement = (value) => {
-  // object: block | inline
-  return isPlainObject(value) && Array.isArray(value.nodes);
-};
 
 /**
  * Converts a sync element to a slate node
@@ -20,27 +12,27 @@ const isElement = (value) => {
 const toSlateNode = (element) => {
   let attrs = {};
   for (const [key, value] of element.entries()) {
-    if (key !== 'children' && key !== 'text' && key !== 'marks') {
+    if (key !== "children" && key !== "text" && key !== "marks") {
       attrs[key] = value;
     }
   }
 
-  const object = element.get('object');
-  if (object === 'block') {
+  const object = element.get("object");
+  if (object === "block") {
     const children = SyncElement.getChildren(element);
     attrs = {
       nodes: children.map(toSlateNode),
       ...attrs,
     };
     return Block.create(attrs);
-  } else if (object === 'inline') {
+  } else if (object === "inline") {
     const children = SyncElement.getChildren(element);
     attrs = {
       nodes: children.map(toSlateNode),
       ...attrs,
     };
     return Inline.create(attrs);
-  } else if (object === 'text') {
+  } else if (object === "text") {
     const text = SyncElement.getText(element);
     attrs = {
       leaves: text.toDelta().map(toSlateLeaf),
@@ -90,17 +82,24 @@ const toSlateMarks = (attributes) => {
  * toSlateDoc(syncDoc: SyncDoc): Node[]
  */
 const toSlateDoc = (syncDoc) => {
-  return syncDoc.map(toSlateNode);
+  const documentNodes = syncDoc.get("document") || [];
+  const nodes = documentNodes.map(toSlateNode);
+  const document = Document.create({ nodes });
+  const data = syncDoc.get("data");
+  return Value.create({ document, data: data ? data.toJSON() : {} });
 };
 
 /**
  * Converts all elements into a Slate doc to SyncElements and adds them to the
  * SyncDoc
  *
- * toSyncDoc(syncDoc: SyncDoc, doc: Node[]): void
+ * toSyncDoc(syncDoc: SyncDoc, value: Value): void
  */
-const toSyncDoc = (syncDoc, doc) => {
-  syncDoc.insert(0, doc.map(toSyncElement));
+const toSyncDoc = (syncDoc, value) => {
+  const document = new Y.Array();
+  document.insert(0, value.document.nodes.map(toSyncElement));
+  syncDoc.set("document", document);
+  syncDoc.set("data", new Y.Map(value.data));
 };
 
 /**
@@ -115,7 +114,7 @@ const toSyncElement = (node) => {
     const childElements = node.nodes.map(toSyncElement);
     const childContainer = new Y.Array();
     childContainer.insert(0, childElements);
-    element.set('children', childContainer);
+    element.set("children", childContainer);
   }
 
   if (Text.isText(node)) {
@@ -131,7 +130,7 @@ const toSyncElement = (node) => {
   }
 
   for (const [key, value] of Object.entries(node.toJSON())) {
-    if (key !== 'leaves' && key !== 'nodes') {
+    if (key !== "leaves" && key !== "nodes") {
       element.set(key, value);
     }
   }
@@ -165,7 +164,7 @@ const toFormattingAttributes = (marks, setMark = true) => {
  * toSlatePath(path: (string | number)[]): Path
  */
 const toSlatePath = (path) => {
-  return path.filter((node) => typeof node === 'number');
+  return path.filter((node) => typeof node === "number");
 };
 
 module.exports = {

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -1,5 +1,4 @@
 const { Block, Document, Inline, Leaf, Mark, Text, Value } = require('slate');
-const isPlainObject = require('is-plain-object');
 const Y = require('yjs');
 const { SyncElement } = require('../model');
 const { Set } = require('immutable');

--- a/test/apply/apply.test.js
+++ b/test/apply/apply.test.js
@@ -1,210 +1,190 @@
 const { applySlateOp, applySlateOps, toSlateDoc} = require('../../src');
 const { createLine, createDoc, createText, createSlateValue } = require('../utils');
 const { List } = require('immutable');
-const { Operation, Text } = require('slate');
+const { Operation, Text, Value } = require('slate');
 const Y = require("yjs")
 
 const transforms = [
   [
-    'insert_text',
-    [
-      createLine([createText('')])
-    ],
+    "insert_text",
+    [createLine([createText("")])],
     [
       {
         marks: [],
         offset: 0,
         path: [0, 0],
-        text: 'Hello ',
-        type: 'insert_text'
+        text: "Hello ",
+        type: "insert_text",
       },
       {
         marks: [],
         offset: 6,
         path: [0, 0],
-        text: 'collaborator',
-        type: 'insert_text'
+        text: "collaborator",
+        type: "insert_text",
       },
       {
         marks: [],
         offset: 18,
         path: [0, 0],
-        text: '!',
-        type: 'insert_text'
-      }
+        text: "!",
+        type: "insert_text",
+      },
     ],
-    [
-      createLine([createText('Hello collaborator!')])
-    ],
+    [createLine([createText("Hello collaborator!")])],
   ],
   [
-    'remove_text',
-    [
-      createLine([createText('Hello collaborator!')])
-    ],
+    "remove_text",
+    [createLine([createText("Hello collaborator!")])],
     [
       {
         offset: 11,
         path: [0, 0],
-        text: 'borator',
-        type: 'remove_text',
-        marks: []
+        text: "borator",
+        type: "remove_text",
+        marks: [],
       },
       {
         offset: 5,
         path: [0, 0],
-        text: ' colla',
-        type: 'remove_text',
-        marks: []
-      }
+        text: " colla",
+        type: "remove_text",
+        marks: [],
+      },
     ],
-    [
-      createLine([createText('Hello!')])
-    ],
+    [createLine([createText("Hello!")])],
   ],
   [
-    'insert_node',
-    [
-      createLine([])
-    ],
+    "insert_node",
+    [createLine([])],
     [
       {
-        type: 'insert_node',
+        type: "insert_node",
         path: [1],
-        node: createLine([])
+        node: createLine([]),
       },
       {
-        type: 'insert_node',
+        type: "insert_node",
         path: [1, 0],
-        node: createText('Hello collaborator!')
-      }
+        node: createText("Hello collaborator!"),
+      },
     ],
-    [
-      createLine([]),
-      createLine([createText('Hello collaborator!')])
-    ]
+    [createLine([]), createLine([createText("Hello collaborator!")])],
   ],
   [
-    'merge_node',
+    "merge_node",
     [
-      createLine([createText('Hello ')]),
-      createLine([createText('collaborator!')])
+      createLine([createText("Hello ")]),
+      createLine([createText("collaborator!")]),
     ],
     [
       {
         path: [1],
         position: 1,
-        properties: { type: 'line' },
+        properties: { type: "line" },
         target: null,
-        type: 'merge_node'
+        type: "merge_node",
       },
       {
         path: [0, 1],
         position: 6,
         properties: {},
         target: null,
-        type: 'merge_node'
-      }
+        type: "merge_node",
+      },
     ],
-    [
-      createLine([createText('Hello collaborator!')])
-    ]
+    [createLine([createText("Hello collaborator!")])],
   ],
   [
-    'move_node',
+    "move_node",
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')]),
-      createLine([createText('fourth')])
+      createLine([createText("first")]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
+      createLine([createText("fourth")]),
     ],
     [
       {
         newPath: [0],
         path: [1],
-        type: 'move_node'
+        type: "move_node",
       },
       {
         newPath: [3, 0],
         path: [2, 0],
-        type: 'move_node'
-      }
+        type: "move_node",
+      },
     ],
     [
-      createLine([createText('second')]),
-      createLine([createText('first')]),
+      createLine([createText("second")]),
+      createLine([createText("first")]),
       createLine([]),
-      createLine([createText('third'), createText('fourth')])
-    ]
+      createLine([createText("third"), createText("fourth")]),
+    ],
   ],
   [
-    'remove_node',
+    "remove_node",
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')])
+      createLine([createText("first")]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
     ],
     [
       {
         path: [1, 0],
-        type: 'remove_node'
+        type: "remove_node",
       },
       {
         path: [0],
-        type: 'remove_node'
-      }
+        type: "remove_node",
+      },
     ],
-    [
-      createLine([]),
-      createLine([createText('third')])
-    ]
+    [createLine([]), createLine([createText("third")])],
   ],
   [
-    'set_node',
+    "set_node",
     [
-      createLine([createText('first')], { test: '1234' }),
-      createLine([createText('second')])
+      createLine([createText("first")], { test: "1234" }),
+      createLine([createText("second")]),
     ],
     [
       {
         path: [0],
-        type: 'set_node',
+        type: "set_node",
         properties: {
           data: {
-            test: '4567'
+            test: "4567",
           },
         },
       },
     ],
     [
-      createLine([createText('first')], { test: '4567' }),
-      createLine([createText('second')]),
-    ]
+      createLine([createText("first")], { test: "4567" }),
+      createLine([createText("second")]),
+    ],
   ],
   [
-    'split_node',
-    [
-      createLine([createText('Hello collaborator!')])
-    ],
+    "split_node",
+    [createLine([createText("Hello collaborator!")])],
     [
       {
         path: [0, 0],
         position: 6,
         properties: {
-          type: 'text'
+          type: "text",
         },
         target: null,
-        type: 'split_node'
+        type: "split_node",
       },
       {
         path: [0],
         position: 1,
         properties: {
-          type: 'line'
+          type: "line",
         },
         target: 6,
-        type: 'split_node'
-      }
+        type: "split_node",
+      },
     ],
     [
       createLine([createText('Hello ')]),
@@ -279,91 +259,92 @@ const transforms = [
 
 const nodeToJSON = (node) => node.toJSON();
 
-describe('apply slate operations to document', () => {
+describe("apply slate operations to document", () => {
   transforms.forEach(([op, input, operations, output]) => {
     it(`apply ${op} operations`, () => {
       const doc = createDoc(input);
-      const content = doc.getMap('content')
-      
+      const content = doc.getMap("content");
+
       doc.transact(() => {
         applySlateOps(content, operations.map(Operation.create));
       });
 
-      const syncDocForAssertion = content.get('document');
-      expect(output.map(nodeToJSON)).toStrictEqual(toSlateDoc(syncDocForAssertion).map(nodeToJSON));
+      expect(Value.create({ document: { nodes: output } }).toJSON()).toEqual(
+        toSlateDoc(content).toJSON()
+      );
     });
   });
 });
 
 const setValueTransform = [
-  'set_value',
-    [
-      createLine([createText('Hello collaborator!')])
-    ],
-    [{
-      type: 'set_value',
+  "set_value",
+  [createLine([createText("Hello collaborator!")])],
+  [
+    {
+      type: "set_value",
       properties: {
-        data:{
-          createdBy:{
+        data: {
+          createdBy: {
             emailAddress: "danielblank07@gmail.com",
             id: "ac8e5fe7-af4e-4281-b1e2-53630606e7c6",
             name: "Daniel Blank",
-            pictureUrl: "https://lh4.googleusercontent.com/-Au4KLfih-zQ/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rcJjTL-m5CILVsClpS2Om3OQycCcQ/photo.jpg",
-            teamId: "8d930c14-9116-4984-b5c8-cdee9432ae87"
-          }
-        }
-      }
-    }]
-    ,
-    [
-      createSlateValue({
-        createdBy:{
-          emailAddress: "danielblank07@gmail.com",
-          id: "ac8e5fe7-af4e-4281-b1e2-53630606e7c6",
-          name: "Daniel Blank",
-          pictureUrl: "https://lh4.googleusercontent.com/-Au4KLfih-zQ/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rcJjTL-m5CILVsClpS2Om3OQycCcQ/photo.jpg",
-          teamId: "8d930c14-9116-4984-b5c8-cdee9432ae87"
-        }
-      }),
-      createLine([createText('Hello collaborator!')])
-    ],
-]
-
+            pictureUrl:
+              "https://lh4.googleusercontent.com/-Au4KLfih-zQ/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rcJjTL-m5CILVsClpS2Om3OQycCcQ/photo.jpg",
+            teamId: "8d930c14-9116-4984-b5c8-cdee9432ae87",
+          },
+        },
+      },
+    },
+  ],
+  [
+    createSlateValue({
+      createdBy: {
+        emailAddress: "danielblank07@gmail.com",
+        id: "ac8e5fe7-af4e-4281-b1e2-53630606e7c6",
+        name: "Daniel Blank",
+        pictureUrl:
+          "https://lh4.googleusercontent.com/-Au4KLfih-zQ/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rcJjTL-m5CILVsClpS2Om3OQycCcQ/photo.jpg",
+        teamId: "8d930c14-9116-4984-b5c8-cdee9432ae87",
+      },
+    }),
+    createLine([createText("Hello collaborator!")]),
+  ],
+];
 
 describe('apply slate "set_value" operations to document', () => {
-  const [op, input, operations, output] = setValueTransform
+  const [op, input, operations, output] = setValueTransform;
   it(`apply ${op} operations`, () => {
     const doc = createDoc(input);
-    const content = doc.getMap('content')
-    
+    const content = doc.getMap("content");
+
     doc.transact(() => {
       applySlateOps(content, operations.map(Operation.create));
     });
-    const syncDocMapForAssertion = content.get('data')
-    const syncDocArrayForAssertion = content.get('document');
-    expect(output.map(nodeToJSON))
-      .toStrictEqual([
-        syncDocMapForAssertion.toJSON(), 
-        ...toSlateDoc(syncDocArrayForAssertion).map(nodeToJSON)
-      ]);
+
+    expect(
+      Value.create({
+        data: output[0],
+        document: { nodes: [output[1]] },
+      }).toJSON()
+    ).toEqual(toSlateDoc(content).toJSON());
   });
 });
 
-describe('apply Invalid slate operation to document', () => {
-  const [op, input, operations, output] = setValueTransform
+describe("apply Invalid slate operation to document", () => {
+  const [op, input, operations, output] = setValueTransform;
   it(`should not change the document`, () => {
     const doc = createDoc(input);
-    const content = doc.getMap('content')
+    const content = doc.getMap("content");
 
     doc.transact(() => {
-      applySlateOp(content, {type:'invalid'});
+      applySlateOp(content, { type: "invalid" });
     });
 
-    const syncDocMapForAssertion = content.get('data')
-    const syncDocArrayForAssertion = content.get('document');
-
-    expect(input.map(nodeToJSON)).toStrictEqual(toSlateDoc(syncDocArrayForAssertion).map(nodeToJSON));
-    expect({}).toStrictEqual(syncDocMapForAssertion.toJSON());
-
+    expect(
+      Value.create({
+        data: output[0],
+        document: { nodes: [output[1]] },
+      }).toJSON()
+    ).toEqual(toSlateDoc(content).toJSON());
   });
 });

--- a/test/collaboration.test.js
+++ b/test/collaboration.test.js
@@ -1,87 +1,87 @@
 const { TestEditor } = require('./testEditor');
 const { toSlateDoc } = require('../src');
 const { createLine, createText } = require('./utils');
-const { Text } = require('slate');
+const { Text, Value } = require('slate');
 const Y = require('yjs');
 
 const tests = [
   [
-    'Insert text into a paragraph node',
-    [createLine([createText('')])],
+    "Insert text into a paragraph node",
+    [createLine([createText("")])],
     [
-      TestEditor.makeInsertText('Hello ', { path: [0, 0], offset: 0 }),
-      TestEditor.makeInsertText('collaborator', { path: [0, 0], offset: 6, }),
-      TestEditor.makeInsertText('!', { path: [0, 0], offset: 18 }),
+      TestEditor.makeInsertText("Hello ", { path: [0, 0], offset: 0 }),
+      TestEditor.makeInsertText("collaborator", { path: [0, 0], offset: 6 }),
+      TestEditor.makeInsertText("!", { path: [0, 0], offset: 18 }),
     ],
-    [createLine([createText('Hello collaborator!')])],
+    [createLine([createText("Hello collaborator!")])],
   ],
   [
-    'Delete characters from a paragraph node',
-    [createLine([createText('Hello collaborator!')])],
+    "Delete characters from a paragraph node",
+    [createLine([createText("Hello collaborator!")])],
     [
       TestEditor.makeRemoveCharacters(7, { path: [0, 0], offset: 11 }),
       TestEditor.makeRemoveCharacters(6, { path: [0, 0], offset: 5 }),
     ],
-    [createLine([createText('Hello!')])],
+    [createLine([createText("Hello!")])],
   ],
   [
-    'Insert new nodes (both paragraph and text)',
-    [createLine([createText('')])],
+    "Insert new nodes (both paragraph and text)",
+    [createLine([createText("")])],
     [
-      TestEditor.makeInsertNodes([createLine([createText('')])], [1]),
-      TestEditor.makeInsertNodes([createText('Hello collaborator!')], [1, 0]),
+      TestEditor.makeInsertNodes([createLine([createText("")])], [1]),
+      TestEditor.makeInsertNodes([createText("Hello collaborator!")], [1, 0]),
     ],
     [
-      createLine([createText('')]),
-      createLine([createText('Hello collaborator!')]),
-    ],
-  ],
-  [
-    'Insert new nodes (two paragraphs)',
-    [
-      createLine([createText('alfa')]),
-      createLine([createText('bravo')]),
-      createLine([createText('charlie')]),
-      createLine([createText('delta')]),
-    ],
-    [
-      TestEditor.makeInsertNodes([createLine([createText('echo')])], [1]),
-      TestEditor.makeInsertNodes([createLine([createText('foxtrot')])], [4]),
-    ],
-    [
-      createLine([createText('alfa')]),
-      createLine([createText('echo')]),
-      createLine([createText('bravo')]),
-      createLine([createText('charlie')]),
-      createLine([createText('foxtrot')]),
-      createLine([createText('delta')]),
+      createLine([createText("")]),
+      createLine([createText("Hello collaborator!")]),
     ],
   ],
   [
-    'Insert new nodes (three paragraphs)',
+    "Insert new nodes (two paragraphs)",
     [
-      createLine([createText('one')]),
-      createLine([createText('two')]),
-      createLine([createText('three')]),
-      createLine([createText('four')]),
+      createLine([createText("alfa")]),
+      createLine([createText("bravo")]),
+      createLine([createText("charlie")]),
+      createLine([createText("delta")]),
     ],
     [
-      TestEditor.makeInsertNodes([createLine([createText('five')])], [1]),
-      TestEditor.makeInsertNodes([createLine([createText('six')])], [3]),
-      TestEditor.makeInsertNodes([createLine([createText('seven')])], [5]),
+      TestEditor.makeInsertNodes([createLine([createText("echo")])], [1]),
+      TestEditor.makeInsertNodes([createLine([createText("foxtrot")])], [4]),
     ],
     [
-      createLine([createText('one')]),
-      createLine([createText('five')]),
-      createLine([createText('two')]),
-      createLine([createText('six')]),
-      createLine([createText('three')]),
-      createLine([createText('seven')]),
-      createLine([createText('four')]),
+      createLine([createText("alfa")]),
+      createLine([createText("echo")]),
+      createLine([createText("bravo")]),
+      createLine([createText("charlie")]),
+      createLine([createText("foxtrot")]),
+      createLine([createText("delta")]),
     ],
   ],
   [
-    'Merge two paragraph nodes',
+    "Insert new nodes (three paragraphs)",
+    [
+      createLine([createText("one")]),
+      createLine([createText("two")]),
+      createLine([createText("three")]),
+      createLine([createText("four")]),
+    ],
+    [
+      TestEditor.makeInsertNodes([createLine([createText("five")])], [1]),
+      TestEditor.makeInsertNodes([createLine([createText("six")])], [3]),
+      TestEditor.makeInsertNodes([createLine([createText("seven")])], [5]),
+    ],
+    [
+      createLine([createText("one")]),
+      createLine([createText("five")]),
+      createLine([createText("two")]),
+      createLine([createText("six")]),
+      createLine([createText("three")]),
+      createLine([createText("seven")]),
+      createLine([createText("four")]),
+    ],
+  ],
+  [
+    "Merge two paragraph nodes",
     [
       createLine([
         Text.create({ leaves: [
@@ -134,227 +134,230 @@ const tests = [
     ],
   ],
   [
-    'Move a paragraph node to the end',
+    "Move a paragraph node to the end",
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')]),
+      createLine([createText("first")]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
     ],
     [TestEditor.makeMoveNodes([0], [3])],
     [
-      createLine([createText('second')]),
-      createLine([createText('third')]),
-      createLine([createText('first')]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
+      createLine([createText("first")]),
     ],
   ],
   [
-    'Move a paragraph node far past the end',
+    "Move a paragraph node far past the end",
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')]),
+      createLine([createText("first")]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
     ],
     [TestEditor.makeMoveNodes([0], [1000])],
     [
-      createLine([createText('second')]),
-      createLine([createText('third')]),
-      createLine([createText('first')]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
+      createLine([createText("first")]),
     ],
   ],
   [
-    'Move a text node',
+    "Move a text node",
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')]),
+      createLine([createText("first")]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
     ],
     [TestEditor.makeMoveNodes([1, 0], [2, 0])],
     [
-      createLine([createText('first')]),
-      createLine([createText('')]),
-      createLine([createText('secondthird')]),
+      createLine([createText("first")]),
+      createLine([createText("")]),
+      createLine([createText("secondthird")]),
     ],
   ],
   [
-    'Remove a paragraph node',
+    "Remove a paragraph node",
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')]),
+      createLine([createText("first")]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
     ],
     [TestEditor.makeRemoveNodes([0])],
-    [createLine([createText('second')]), createLine([createText('third')])],
+    [createLine([createText("second")]), createLine([createText("third")])],
   ],
   [
-    'Remove two non-consecutive paragraph nodes',
+    "Remove two non-consecutive paragraph nodes",
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')]),
-      createLine([createText('fourth')]),
+      createLine([createText("first")]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
+      createLine([createText("fourth")]),
     ],
     [TestEditor.makeRemoveNodes([0]), TestEditor.makeRemoveNodes([1])],
-    [createLine([createText('second')]), createLine([createText('fourth')])],
+    [createLine([createText("second")]), createLine([createText("fourth")])],
   ],
   [
-    'Remove two consecutive paragraph nodes',
+    "Remove two consecutive paragraph nodes",
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')]),
-      createLine([createText('fourth')]),
+      createLine([createText("first")]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
+      createLine([createText("fourth")]),
     ],
     [TestEditor.makeRemoveNodes([1]), TestEditor.makeRemoveNodes([1])],
-    [createLine([createText('first')]), createLine([createText('fourth')])],
+    [createLine([createText("first")]), createLine([createText("fourth")])],
   ],
   [
-    'Remove a text node',
+    "Remove a text node",
     [
-      createLine([createText('first')]),
-      createLine([createText('second')]),
-      createLine([createText('third')]),
+      createLine([createText("first")]),
+      createLine([createText("second")]),
+      createLine([createText("third")]),
     ],
     [TestEditor.makeRemoveNodes([1, 0])],
     [
-      createLine([createText('first')]),
-      createLine([createText('')]),
-      createLine([createText('third')]),
+      createLine([createText("first")]),
+      createLine([createText("")]),
+      createLine([createText("third")]),
     ],
   ],
   [
-    'Set properties of a paragraph node',
+    "Set properties of a paragraph node",
     [
-      createLine([createText('first')], { test: '1234' }),
-      createLine([createText('second')]),
+      createLine([createText("first")], { test: "1234" }),
+      createLine([createText("second")]),
     ],
-    [TestEditor.makeSetNodes([0], { test: '4567' })],
+    [TestEditor.makeSetNodes([0], { test: "4567" })],
     [
-      createLine([createText('first')], { test: '4567' }),
-      createLine([createText('second')]),
+      createLine([createText("first")], { test: "4567" }),
+      createLine([createText("second")]),
     ],
   ],
   [
-    'Split an existing paragraph',
-    [createLine([createText('Hello collaborator!')])],
+    "Split an existing paragraph",
+    [createLine([createText("Hello collaborator!")])],
     [TestEditor.makeSplitNodes({ path: [0, 0], offset: 6 })],
     [
-      createLine([createText('Hello ')]),
-      createLine([createText('collaborator!')]),
+      createLine([createText("Hello ")]),
+      createLine([createText("collaborator!")]),
     ],
   ],
   [
-    'Insert and remove text in the same paragraph',
-    [createLine([createText('abc def')])],
+    "Insert and remove text in the same paragraph",
+    [createLine([createText("abc def")])],
     [
-      TestEditor.makeInsertText('ghi ', { path: [0, 0], offset: 4 }),
+      TestEditor.makeInsertText("ghi ", { path: [0, 0], offset: 4 }),
       TestEditor.makeRemoveCharacters(2, { path: [0, 0], offset: 1 }),
-      TestEditor.makeInsertText('jkl ', { path: [0, 0], offset: 6 }),
+      TestEditor.makeInsertText("jkl ", { path: [0, 0], offset: 6 }),
       TestEditor.makeRemoveCharacters(1, { path: [0, 0], offset: 11 }),
-      TestEditor.makeInsertText(' mno', { path: [0, 0], offset: 12 }),
+      TestEditor.makeInsertText(" mno", { path: [0, 0], offset: 12 }),
     ],
-    [createLine([createText('a ghi jkl df mno')])],
+    [createLine([createText("a ghi jkl df mno")])],
   ],
   [
-    'Remove first paragraph, insert text into second paragraph',
-    [createLine([createText('abcd')]), createLine([createText('efgh')])],
+    "Remove first paragraph, insert text into second paragraph",
+    [createLine([createText("abcd")]), createLine([createText("efgh")])],
     [
       TestEditor.makeRemoveNodes([0]),
-      TestEditor.makeInsertText(' ijkl ', { path: [0, 0], offset: 2 }),
+      TestEditor.makeInsertText(" ijkl ", { path: [0, 0], offset: 2 }),
     ],
-    [createLine([createText('ef ijkl gh')])],
+    [createLine([createText("ef ijkl gh")])],
   ],
   [
-    'More complex case: insert text, both insert and remove nodes',
+    "More complex case: insert text, both insert and remove nodes",
     [
-      createLine([createText('abcd')]),
-      createLine([createText('efgh')]),
-      createLine([createText('ijkl')]),
+      createLine([createText("abcd")]),
+      createLine([createText("efgh")]),
+      createLine([createText("ijkl")]),
     ],
     [
-      TestEditor.makeInsertText(' mnop ', { path: [0, 0], offset: 2 }),
+      TestEditor.makeInsertText(" mnop ", { path: [0, 0], offset: 2 }),
       TestEditor.makeRemoveNodes([1]),
-      TestEditor.makeInsertText(' qrst ', { path: [1, 0], offset: 2 }),
-      TestEditor.makeInsertNodes([createLine([createText('uvxw')])], [1]),
+      TestEditor.makeInsertText(" qrst ", { path: [1, 0], offset: 2 }),
+      TestEditor.makeInsertNodes([createLine([createText("uvxw")])], [1]),
     ],
     [
-      createLine([createText('ab mnop cd')]),
-      createLine([createText('uvxw')]),
-      createLine([createText('ij qrst kl')]),
+      createLine([createText("ab mnop cd")]),
+      createLine([createText("uvxw")]),
+      createLine([createText("ij qrst kl")]),
     ],
   ],
   [
-    'Insert text, then insert node that affects the path to the affected text',
-    [createLine([createText('abcd')])],
+    "Insert text, then insert node that affects the path to the affected text",
+    [createLine([createText("abcd")])],
     [
-      TestEditor.makeInsertText(' efgh ', { path: [0, 0], offset: 2 }),
-      TestEditor.makeInsertNodes([createLine([createText('ijkl')])], [0]),
+      TestEditor.makeInsertText(" efgh ", { path: [0, 0], offset: 2 }),
+      TestEditor.makeInsertNodes([createLine([createText("ijkl")])], [0]),
     ],
-    [createLine([createText('ijkl')]), createLine([createText('ab efgh cd')])],
+    [createLine([createText("ijkl")]), createLine([createText("ab efgh cd")])],
   ],
   [
-    'Set properties, then insert node that affects path to the affected node',
-    [createLine([createText('abcd')])],
+    "Set properties, then insert node that affects path to the affected node",
+    [createLine([createText("abcd")])],
     [
-      TestEditor.makeSetNodes([0], { test: '1234' }),
-      TestEditor.makeInsertNodes([createLine([createText('ijkl')])], [0]),
+      TestEditor.makeSetNodes([0], { test: "1234" }),
+      TestEditor.makeInsertNodes([createLine([createText("ijkl")])], [0]),
     ],
     [
-      createLine([createText('ijkl')]),
-      createLine([createText('abcd')], { test: '1234' }),
+      createLine([createText("ijkl")]),
+      createLine([createText("abcd")], { test: "1234" }),
     ],
   ],
   [
-    'Insert node, then insert second node that affects path to the first node',
+    "Insert node, then insert second node that affects path to the first node",
     [
       createLine([
-        createLine([createText('abc')]),
-        createLine([createText('def')]),
+        createLine([createText("abc")]),
+        createLine([createText("def")]),
       ]),
     ],
     [
-      TestEditor.makeInsertNodes([createLine([createText('jkl')])], [0, 1]),
-      TestEditor.makeInsertNodes([createLine([createText('ghi')])], [0]),
+      TestEditor.makeInsertNodes([createLine([createText("jkl")])], [0, 1]),
+      TestEditor.makeInsertNodes([createLine([createText("ghi")])], [0]),
     ],
     [
-      createLine([createText('ghi')]),
+      createLine([createText("ghi")]),
       createLine([
-        createLine([createText('abc')]),
-        createLine([createText('jkl')]),
-        createLine([createText('def')]),
+        createLine([createText("abc")]),
+        createLine([createText("jkl")]),
+        createLine([createText("def")]),
       ]),
     ],
   ],
   [
-    'remove_text op spans location of previous remove_text op',
-    [createLine([createText('abc defg ijklm')])],
+    "remove_text op spans location of previous remove_text op",
+    [createLine([createText("abc defg ijklm")])],
     [TestEditor.makeRemoveCharacters(5, { path: [0, 0], offset: 4 })],
-    [createLine([createText('abc ijklm')])],
+    [createLine([createText("abc ijklm")])],
     [TestEditor.makeRemoveCharacters(6, { path: [0, 0], offset: 1 })],
-    [createLine([createText('alm')])],
+    [createLine([createText("alm")])],
   ],
   [
-    'remove_text op spans locations of two previous remove_text ops',
-    [createLine([createText('abcdefghijklmnopqrst')])],
+    "remove_text op spans locations of two previous remove_text ops",
+    [createLine([createText("abcdefghijklmnopqrst")])],
     [TestEditor.makeRemoveCharacters(3, { path: [0, 0], offset: 2 })],
-    [createLine([createText('abfghijklmnopqrst')])],
+    [createLine([createText("abfghijklmnopqrst")])],
     [TestEditor.makeRemoveCharacters(8, { path: [0, 0], offset: 5 })],
-    [createLine([createText('abfghqrst')])],
+    [createLine([createText("abfghqrst")])],
     [TestEditor.makeRemoveCharacters(7, { path: [0, 0], offset: 1 })],
-    [createLine([createText('at')])],
+    [createLine([createText("at")])],
   ],
   [
-    'Set Value to slate and Yjs',
-    [createLine([createText('')])],
+    "Set Value to slate and Yjs",
+    [createLine([createText("")])],
     [
-      TestEditor.makeSetValue({createdBy:{
-        emailAddress: "danielblank07@gmail.com",
-        id: "ac8e5fe7-af4e-4281-b1e2-53630606e7c6",
-        name: "Daniel Blank",
-        pictureUrl: "https://lh4.googleusercontent.com/-Au4KLfih-zQ/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rcJjTL-m5CILVsClpS2Om3OQycCcQ/photo.jpg",
-        teamId: "8d930c14-9116-4984-b5c8-cdee9432ae87"
-      }})
+      TestEditor.makeSetValue({
+        createdBy: {
+          emailAddress: "danielblank07@gmail.com",
+          id: "ac8e5fe7-af4e-4281-b1e2-53630606e7c6",
+          name: "Daniel Blank",
+          pictureUrl:
+            "https://lh4.googleusercontent.com/-Au4KLfih-zQ/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rcJjTL-m5CILVsClpS2Om3OQycCcQ/photo.jpg",
+          teamId: "8d930c14-9116-4984-b5c8-cdee9432ae87",
+        },
+      }),
     ],
-    [createLine([createText('')])],
+    [createLine([createText("")])],
   ],
   [
     'Add marks to existing text',
@@ -424,25 +427,15 @@ const tests = [
 
 const nodeToJSON = (node) => node.toJSON();
 
-// Returns slate document as JSON.
-const getSlateDocAsJSON = (editor) => {
-  return editor.slateDoc.document.nodes.toArray().map(nodeToJSON);
-};
-
-// Returns sync document converted to slate format as JSON.
-const getSyncDocAsJSON = (editor) => {
-  return toSlateDoc(editor.syncDoc.get('document')).map(nodeToJSON);
-};
-
-describe('slate operations propagate between editors', () => {
+describe("slate operations propagate between editors", () => {
   tests.forEach(([testName, input, ...rest]) => {
     it(`${testName}`, () => {
       // Create two editors.
       const src = TestEditor.create();
       const dst = TestEditor.create();
 
-      src.syncDoc.set("data", new Y.Map())
-      src.syncDoc.set("document", new Y.Array())
+      src.syncDoc.set("data", new Y.Map());
+      src.syncDoc.set("document", new Y.Array());
 
       // Set initial state for src editor, propagate changes to dst editor.
       TestEditor.applyTransform(src, TestEditor.makeInsertNodes(input, [0]));
@@ -452,32 +445,36 @@ describe('slate operations propagate between editors', () => {
 
       // Verify initial states.
       const inputAsJSON = input.map(nodeToJSON);
-      expect(getSlateDocAsJSON(src)).toStrictEqual(inputAsJSON);
-      expect(getSyncDocAsJSON(src)).toStrictEqual(inputAsJSON);
-      expect(getSyncDocAsJSON(dst)).toStrictEqual(inputAsJSON);
-      expect(getSlateDocAsJSON(dst)).toStrictEqual(inputAsJSON);
+      const inputValue = Value.create({
+        document: { nodes: inputAsJSON },
+      });
+      expect(src.slateDoc.document.nodes.toArray().map(nodeToJSON)).toStrictEqual(inputAsJSON);
+      expect(toSlateDoc(src.syncDoc).toJSON()).toEqual(inputValue.toJSON());
+      expect(toSlateDoc(dst.syncDoc).toJSON()).toEqual(inputValue.toJSON());
+      expect(dst.slateDoc.document.nodes.toArray().map(nodeToJSON)).toStrictEqual(inputAsJSON);
 
-      // Allow for multiple rounds of applying transforms and verifying state.
-      while (rest.length > 0) {
-        let transforms, output;
-        [transforms, output, ...rest] = rest;
+        // Allow for multiple rounds of applying transforms and verifying state.
+        while (rest.length > 0) {
+          let transforms, output;
+          [transforms, output, ...rest] = rest;
 
-        // Apply transforms to src editor, propagate changes to dst editor.
-        TestEditor.applyTransforms(src, transforms);
-        updates = TestEditor.getCapturedYjsUpdates(src);
-        TestEditor.applyYjsUpdatesToYjs(dst, updates);
+          // Apply transforms to src editor, propagate changes to dst editor.
+          TestEditor.applyTransforms(src, transforms);
+          updates = TestEditor.getCapturedYjsUpdates(src);
+          TestEditor.applyYjsUpdatesToYjs(dst, updates);
 
-        // Verify final 'document' states.
-        const outputAsJSON = output.map(nodeToJSON);
-        expect(getSlateDocAsJSON(src)).toStrictEqual(outputAsJSON);
-        expect(getSyncDocAsJSON(src)).toStrictEqual(outputAsJSON);
-        expect(getSyncDocAsJSON(dst)).toStrictEqual(outputAsJSON);
-        expect(getSlateDocAsJSON(dst)).toStrictEqual(outputAsJSON);
-
-        // Verify final 'data' states.
-        expect(dst.syncDoc.get('data').toJSON()).toStrictEqual(src.syncDoc.get('data').toJSON());
-        expect(src.slateDoc.data.toJSON()).toStrictEqual(dst.slateDoc.data.toJSON());
-      }
+          // Verify final states.
+          const outputAsJSON = output.map(nodeToJSON);
+          const outputValue = Value.create({
+            document: { nodes: outputAsJSON },
+          });
+          expect(src.slateDoc.document.nodes.toArray().map(nodeToJSON)).toStrictEqual(outputAsJSON);
+          expect(toSlateDoc(src.syncDoc).toJSON()).toStrictEqual(outputValue.toJSON());
+          expect(toSlateDoc(dst.syncDoc).toJSON()).toStrictEqual(outputValue.toJSON());
+          expect(dst.syncDoc.get('data').toJSON()).toStrictEqual(src.syncDoc.get('data').toJSON());
+          expect(dst.slateDoc.document.nodes.toArray().map(nodeToJSON)).toStrictEqual(outputAsJSON);
+          expect(src.slateDoc.data.toJSON()).toStrictEqual(dst.slateDoc.data.toJSON());
+        }
     });
   });
 });

--- a/test/convert/convert.test.js
+++ b/test/convert/convert.test.js
@@ -1,58 +1,53 @@
-const { Text } = require('slate');
-const { toSlateDoc, toSyncDoc } = require('../../src');
-const { createLine, createMention, createText } = require('../utils');
-const Y = require('yjs');
+const { Value, Text } = require("slate");
+const { toSlateDoc, toSyncDoc } = require("../../src");
+const { createLine, createMention, createText } = require("../utils");
+const Y = require("yjs");
 
 const tests = [
   [
-    'text node',
-    createText('abc')
-  ],
-  [
-    'inline node',
-    createMention([createText('@def')])
-  ],
-  [
-    'block node',
+    "block node with inline",
     createLine([
-      createText('ghi'), 
-      createMention([createText('@jkl')])
-    ])
+      createText("ghi"),
+      createMention([createText("@jkl")]),
+      createText(""),
+    ]),
   ],
   [
-    'block node with properties',
-    createLine([createText('mno')], { pqr: 'stu' })
+    "block node with properties",
+    createLine([createText("mno")], { pqr: "stu" }),
   ],
   [
-    'text with marks',
-    Text.create({
-      leaves: [
-        { text: 'ab' },
-        {
-          text: 'cde',
-          marks: [{ type: 'strong' }]
-        },
-        {
-          text: 'fghi',
-          marks: [{ type: 'em' }, { type: 'underline' }]
-        },
-        { text: 'jklmn' },
-      ],
-    })
+    "text with marks",
+    createLine([
+      Text.create({
+        leaves: [
+          { text: "ab" },
+          {
+            text: "cde",
+            marks: [{ type: "strong" }],
+          },
+          {
+            text: "fghi",
+            marks: [{ type: "em" }, { type: "underline" }],
+          },
+          { text: "jklmn" },
+        ],
+      }),
+    ]),
   ],
 ];
 
 const nodeToJS = (node) => node.toJS();
 
-describe('convert', () => {
+describe("convert", () => {
   tests.forEach(([testName, input]) => {
     it(`${testName}`, () => {
       const doc = new Y.Doc();
-      const syncArray = doc.getArray('document');
+      const syncDoc = doc.getMap("content");
 
-      toSyncDoc(syncArray, [input]);
-      const output = toSlateDoc(syncArray);
-      expect(output.map(nodeToJS)).toStrictEqual([nodeToJS(input)]);
+      toSyncDoc(syncDoc, Value.create({ document: { nodes: [input] } }));
+      const output = toSlateDoc(syncDoc);
+      expect(output.document.nodes.toJS()).toStrictEqual([nodeToJS(input)]);
     });
   });
 });

--- a/test/toSlateDoc.test.js
+++ b/test/toSlateDoc.test.js
@@ -1,0 +1,44 @@
+const { Value } = require("slate");
+const { toSyncDoc, toSlateDoc } = require("../src");
+const Y = require("yjs");
+
+describe("toSlateDoc", () => {
+  it("should replicate the Yjs doc to the Slate value", () => {
+    const documentNodes = [
+      {
+        object: "block",
+        type: "line",
+        nodes: [
+          {
+            object: "text",
+            leaves: [
+              {
+                text: "Hello world!",
+                marks: [],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const data = {
+      actions: [{ id: "test-id", user: { name: "test-name" } }],
+      access: { public: true },
+    };
+    const value = Value.fromJSON({
+      object: "value",
+      document: {
+        object: "document",
+        nodes: documentNodes,
+      },
+      data,
+    });
+
+    const doc = new Y.Doc();
+    const syncDoc = doc.getMap("content");
+    toSyncDoc(syncDoc, value);
+    const convertedValue = toSlateDoc(syncDoc);
+
+    expect(convertedValue.toJSON()).toStrictEqual(value.toJSON());
+  });
+});

--- a/test/toSyncDoc.test.js
+++ b/test/toSyncDoc.test.js
@@ -1,0 +1,58 @@
+const { Value } = require("slate");
+const { toSyncDoc } = require("../src");
+const Y = require("yjs");
+
+describe("toSyncDoc", () => {
+  it("should replicate the Slate value to the Yjs doc", () => {
+    const documentNodes = [
+      {
+        object: "block",
+        type: "line",
+        nodes: [
+          {
+            object: "text",
+            leaves: [
+              {
+                text: "Hello world!",
+                marks: [],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const data = {
+      actions: [{ id: "test-id", user: { name: "test-name" } }],
+      access: { public: true },
+    };
+    const value = Value.fromJSON({
+      object: "value",
+      document: {
+        object: "document",
+        nodes: documentNodes,
+      },
+      data,
+    });
+
+    const doc = new Y.Doc();
+    const syncDoc = doc.getMap("content");
+
+    toSyncDoc(syncDoc, value);
+    expect(syncDoc.toJSON()).toStrictEqual({
+      document: [
+        {
+          object: "block",
+          type: "line",
+          data: {},
+          children: [
+            {
+              text: "Hello world!",
+              object: "text",
+            },
+          ],
+        },
+      ],
+      data,
+    });
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,11 +1,11 @@
-const { Block, Inline, Text, Value } = require('slate');
-const Y = require('yjs');
-const { toSyncDoc } = require('../src');
+const { Block, Inline, Text, Value } = require("slate");
+const Y = require("yjs");
+const { toSyncDoc } = require("../src");
 
 const createLine = (children, properties = {}) => {
   return Block.fromJSON({
-    object: 'block',
-    type: 'line',
+    object: "block",
+    type: "line",
     data: properties,
     nodes: children,
   });
@@ -13,44 +13,43 @@ const createLine = (children, properties = {}) => {
 
 const createMention = (children, properties = {}) => {
   return Inline.fromJSON({
-    object: 'inline',
-    type: 'mention',
+    object: "inline",
+    type: "mention",
     data: properties,
     nodes: children,
   });
 };
 
-const createText = (text = '') => {
+const createText = (text = "") => {
   return Text.fromJSON({
-    object: 'text',
+    object: "text",
     leaves: [
       {
-        object: 'leaf',
+        object: "leaf",
         text,
         marks: [],
-      }
+      },
     ],
   });
 };
 
-const createValue = (children) => ({
-  children: children || [createNode()]
-});
-
 const createSlateValue = (properties) => {
-  return Value.create().change().setValue({data:properties}).value.data
-}
+  return Value.create().change().setValue({ data: properties }).value.data;
+};
 
 const createDoc = (children) => {
   const doc = new Y.Doc();
-  const innerDocument = new Y.Array()
+  const innerDocument = doc.getMap("content");
 
-  toSyncDoc(innerDocument, createValue(children).children)
-
-  doc.getMap('content').set('document', innerDocument)
-  doc.getMap('content').set('data', new Y.Map())
+  toSyncDoc(innerDocument, Value.create({ document: { nodes: children } }));
 
   return doc;
 };
 
-module.exports = { createLine, createMention, createText, createDoc, createSlateValue };
+module.exports = {
+  createLine,
+  createMention,
+  createText,
+  createDoc,
+  createSlateValue,
+};


### PR DESCRIPTION
Sorry for the double quote changes – VSCode does that automatically based on the `prettier` schema for each project and I only noticed afterwards 🤦‍♂️ 