### PR TITLE
Fix failing tests

### DIFF
--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -70,7 +70,7 @@ const toSlateMarks = (attributes) => {
   if (!!attributes) {
     for (const markType in attributes) {
       let markAttrs = { type: markType };
-      if (attributes[markType] !== "true") {
+      if (attributes[markType] !== null && attributes[markType] !== "true") {
         markAttrs = { data: { value: attributes[markType] }, ...markAttrs };
       }
       marks.push(Mark.create(markAttrs));

--- a/test/collaboration.test.js
+++ b/test/collaboration.test.js
@@ -426,6 +426,7 @@ const tests = [
 ];
 
 const nodeToJSON = (node) => node.toJSON();
+
 // Returns slate document as JSON.
 const getSlateDocAsJSON = (editor) => {
   return editor.slateDoc.document.nodes.toArray().map(nodeToJSON)

--- a/test/formattingMarks.test.js
+++ b/test/formattingMarks.test.js
@@ -78,5 +78,8 @@ describe("toSlateMarks", () => {
       expect(toSlateMarks(yjsFormattingAttributes)).toEqual(slateMarks);
     });
   });
-});
 
+  it("Clear mark", () => {
+    expect(toSlateMarks({ em: null })).toEqual([ Mark.create({ type: "em" }) ]);
+  });
+});


### PR DESCRIPTION
* https://github.com/hugoai/hg-slate-yjs/pull/20 introduced bug in removal-of-formatting flow in the Yjs->Slate path

* Fixed the bug, extended formattingMarks.test.js to cover that case

* All tests pass again