### PR TITLE
Change setValue.js to handle missing data property gracefully

### DIFF
--- a/src/apply/value/setValue.js
+++ b/src/apply/value/setValue.js
@@ -1,15 +1,15 @@
 const Y = require('yjs');
 
-const setValue = (doc, op)=>{
+const setValue = (doc, op) => {
+  if (op.properties && op.properties.data) {
     const newData = new Y.Map()
-
     for (const [key, value] of Object.entries(op.properties.data.toJSON())) {
-        newData.set(key, value)
+      newData.set(key, value);
     }
+    doc.set("data", newData);
+  }
 
-    doc.set("data", newData)
-    
-    return doc
+  return doc;
 }
 
 


### PR DESCRIPTION
* Eliminates 'TypeError: Cannot read property 'toJSON' of undefined' errors that were spamming console