### PR TITLE
Change Yjs rep for {text,highlight}_color marks

### DIFF
--- a/src/convert/textEvent.js
+++ b/src/convert/textEvent.js
@@ -1,4 +1,4 @@
-const { toSlateMarks, toSlatePath } = require('../utils/convert');
+const { toFormattingAttributesKey, toSlateMarks, toSlatePath } = require('../utils/convert');
 
 /**
  * Converts a Yjs Text event into Slate operations.
@@ -33,7 +33,7 @@ const textEvent = (event) => {
    */
   const createMarkOps = (offset, length, attributes) => {
     return toSlateMarks(attributes).map(mark => ({
-      type: ((attributes[mark.type] !== null) ? 'add_mark' : 'remove_mark'),
+      type: ((attributes[toFormattingAttributesKey(mark)] !== null) ? 'add_mark' : 'remove_mark'),
       path: eventTargetPath,
       offset,
       length,

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -69,9 +69,10 @@ const toSlateMarks = (attributes) => {
   const marks = [];
   if (!!attributes) {
     for (const markType in attributes) {
-      let markAttrs = { type: markType };
-      if (attributes[markType] !== null && attributes[markType] !== "true") {
-        markAttrs = { data: { value: attributes[markType] }, ...markAttrs };
+      const s = markType.split(':');
+      let markAttrs = { type: s[0] };
+      if (s.length > 1) {
+        markAttrs = { data: { value: s[1] }, ...markAttrs };
       }
       marks.push(Mark.create(markAttrs));
     }
@@ -142,6 +143,20 @@ const toSyncElement = (node) => {
 };
 
 /**
+ * Returns the formatting attributes key that should be used for the given slate
+ * Mark.
+ *
+ * toFormattingAttributesKey(Mark): string
+ */
+const toFormattingAttributesKey = (mark) => {
+  let key = mark.type;
+  if (mark.data && mark.data.has("value")) {
+    key = `${key}:${mark.data.get("value")}`;
+  }
+  return key;
+};
+
+/**
  * Converts a List of slate Marks to Yjs formatting attributes
  *
  * toFormattingAttributes(List<Mark>, boolean): Object<string, string>
@@ -151,15 +166,7 @@ const toFormattingAttributes = (marks, setMark = true) => {
   marks.forEach(mark => {
     // If setMark is false, use a value of null to indicate that application of
     // the resulting formatting attributes should cause the mark to be cleared.
-    let value = null;
-    if (setMark) {
-      if (mark.data && mark.data.has("value")) {
-        value = mark.data.get("value");
-      } else {
-        value = "true";
-      }
-    }
-    result[mark.type] = value;
+    result[toFormattingAttributesKey(mark)] = setMark ? "true" : null;
   })
   return result;
 };
@@ -175,6 +182,7 @@ const toSlatePath = (path) => {
 
 module.exports = {
   toFormattingAttributes,
+  toFormattingAttributesKey,
   toSlateMarks,
   toSlateNode,
   toSlateDoc,

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -61,20 +61,29 @@ const toSlateLeaf = (delta) => {
 }
 
 /**
+ * Converts a Yjs formatting attributes key to the corresponding slate Mark
+ *
+ * toSlateMark(string): Mark
+ */
+const toSlateMark = (formattingAttributesKey) => {
+  const s = formattingAttributesKey.split(':');
+  let markAttrs = { type: s[0] };
+  if (s.length > 1) {
+    markAttrs = { data: { value: s[1] }, ...markAttrs };
+  }
+  return Mark.create(markAttrs);
+}
+
+/**
  * Converts Yjs formatting attributes to a List of slate Marks
  *
  * toSlateMarks(Object<string, string>): Mark[]
  */
-const toSlateMarks = (attributes) => {
+const toSlateMarks = (formattingAttributes) => {
   const marks = [];
-  if (!!attributes) {
-    for (const markType in attributes) {
-      const s = markType.split(':');
-      let markAttrs = { type: s[0] };
-      if (s.length > 1) {
-        markAttrs = { data: { value: s[1] }, ...markAttrs };
-      }
-      marks.push(Mark.create(markAttrs));
+  if (!!formattingAttributes) {
+    for (const formattingAttributesKey in formattingAttributes) {
+      marks.push(toSlateMark(formattingAttributesKey));
     }
   }
   return marks;

--- a/test/formattingMarks.test.js
+++ b/test/formattingMarks.test.js
@@ -36,12 +36,12 @@ const tests = [
   [
     "Text color",
     [ Mark.create({ type: "text_color", data: { value: "#123456" }}) ],
-    { text_color: "#123456" }
+    { 'text_color:#123456': "true" }
   ],
   [
     "Highlight color",
     [ Mark.create({ type: "highlight_color", data: { value: "#edcba9" }}) ],
-    { highlight_color: "#edcba9" }
+    { 'highlight_color:#edcba9': "true" }
   ],
   [
     "Text and highlight colors",
@@ -50,8 +50,8 @@ const tests = [
       Mark.create({ type: "highlight_color", data: { value: "#dcba98" }})
     ],
     {
-      text_color: "#234567",
-      highlight_color: "#dcba98"
+      'text_color:#234567': "true",
+      'highlight_color:#dcba98': "true"
     }
   ],
 ];


### PR DESCRIPTION
* After this change, use {text,highlight}_color:${color_value} properties (with a corresponding value of "true") in formatting attributes objects.

* Previously, we had been using {text,highlight}_color properties (with a corresponding value of ${color_value}) in formatting attributes objects, but this made it difficult to determine the correct ${color_value} to use when decoding Y.TextEvents that yielded 'remove_mark' ops.

* With this approach, the existing textEvent.js logic can be used *almost* unchanged (only one small change to the logic that determines whether to create an 'add_mark' or 'remove_mark' op).